### PR TITLE
chore: 3x speedup, 0.33x memory usage, one line :) (SE model)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arc-state"
-version = "0.9.3"
+version = "0.9.7"
 description = "State is a machine learning model that predicts cellular perturbation response across diverse contexts."
 readme = "README.md"
 authors = [

--- a/src/state/emb/inference.py
+++ b/src/state/emb/inference.py
@@ -94,7 +94,7 @@ class Inference:
             raise ValueError("Model already initialized")
 
         # Load and initialize model for eval
-        self.model = StateEmbeddingModel.load_from_checkpoint(checkpoint, strict=False)
+        self.model = StateEmbeddingModel.load_from_checkpoint(checkpoint, dropout=0.0, strict=False)
         all_pe = self.protein_embeds or get_embeddings(self._vci_conf)
         if isinstance(all_pe, dict):
             all_pe = torch.vstack(list(all_pe.values()))


### PR DESCRIPTION
### Before
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg       CPU Mem  Self CPU Mem    # of Calls
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                              aten::mul         3.30%        2.370s         3.30%        2.371s      43.901ms      45.20 Gb      45.20 Gb            54
                                              aten::bmm         9.40%        6.741s         9.41%        6.752s     210.996ms      42.54 Gb      42.54 Gb            32
                                         aten::_softmax         3.90%        2.795s         3.90%        2.795s     164.394ms      40.04 Gb      40.04 Gb            17
                                    aten::empty_strided         0.00%     731.886us         0.00%     731.886us       7.393us      40.04 Gb      40.04 Gb            99
                                            aten::empty         0.05%      33.079ms         0.05%      33.079ms       0.265us      17.52 Gb      17.34 Gb        125061
                                            aten::addmm         9.34%        6.697s        10.09%        7.239s     100.545ms      15.95 Gb      15.95 Gb            72
                                         aten::isneginf         0.90%     643.522ms         0.90%     643.522ms      40.220ms      10.01 Gb      10.01 Gb            16
                                              aten::add         0.22%     159.903ms         0.22%     159.905ms       4.322ms       5.32 Gb       5.32 Gb            37
                                             aten::gelu         0.31%     220.079ms         0.31%     220.079ms      13.755ms       2.50 Gb       2.50 Gb            16
                                              aten::cat         0.40%     287.910ms         0.40%     287.973ms      71.993ms     946.82 Mb     946.82 Mb             4
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 71.732s
```

![image](https://github.com/user-attachments/assets/d7de7cb5-ebc7-458f-9e84-71066f097183)


### After
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg       CPU Mem  Self CPU Mem    # of Calls
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                            aten::addmm        24.38%        6.506s        26.74%        7.136s      99.114ms      15.95 Gb      15.95 Gb            72
                                            aten::empty         0.13%      35.763ms         0.13%      35.763ms       0.286us       7.71 Gb       7.65 Gb        125045
                                              aten::add         0.56%     149.229ms         0.56%     149.231ms       4.033ms       5.32 Gb       5.32 Gb            37
                                    aten::empty_strided         0.00%     125.754us         0.00%     125.754us       2.466us       2.50 Gb       2.50 Gb            51
                                             aten::gelu         0.69%     185.245ms         0.69%     185.245ms      11.578ms       2.50 Gb       2.50 Gb            16
                                              aten::cat         0.69%     184.891ms         0.69%     184.939ms      46.235ms     946.82 Mb     946.82 Mb             4
                                     aten::index_select         0.10%      25.418ms         0.10%      25.438ms       8.479ms     700.08 Mb     700.08 Mb             3
                                              aten::div         0.05%      13.710ms         0.05%      13.710ms       4.570ms     400.08 Mb     400.08 Mb             3
                                        aten::clamp_min         0.03%       8.231ms         0.03%       8.231ms       2.744ms     320.23 Mb     320.23 Mb             3
                                             aten::silu         0.04%      11.837ms         0.04%      11.837ms       5.918ms     280.08 Mb     280.08 Mb             2
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 26.684s
```

![image](https://github.com/user-attachments/assets/5549d5ad-15de-43cc-8f2b-e4f07292d272)

`dropout=0.1` during inference stopped FA from being used.