### PR TITLE
Fix: Update .gitignore to not exclude `wandb` OmegaConf config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ notebooks/
 *.sif
 *.slurm
 temp
-wandb/
+/wandb/


### PR DESCRIPTION
## What
- Only specify the top-level `wandb` directory in the `.gitignore`

## Why
- You're now also excluding the `/src/state/configs/wandb` config folder.

Specifically, I noticed it when installing `arc-state` from source through `uv`. To reproduce:
```
uv init
uv add "arc-state @ git+https://github.com/ArcInstitute/state"
```

The `wandb` config directory will be missing. Running training, for example, results in: 
```
hydra.errors.MissingConfigException: In 'config': Could not find 'wandb/default'

Config search path:
        provider=hydra, path=pkg://hydra.conf
        provider=main, path=file:///.../.venv/lib/python3.13/site-packages/state/configs
        provider=schema, path=structured://
```