### PR TITLE
(fix): Fix masked attention tensor dtype and dimensionality issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arc-state"
-version = "0.9.27"
+version = "0.9.28"
 description = "State is a machine learning model that predicts cellular perturbation response across diverse contexts."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arc-state"
-version = "0.9.29"
+version = "0.9.30"
 description = "State is a machine learning model that predicts cellular perturbation response across diverse contexts."
 readme = "README.md"
 authors = [

--- a/src/state/tx/models/state_transition.py
+++ b/src/state/tx/models/state_transition.py
@@ -386,10 +386,13 @@ class StateTransitionPerturbationModel(PerturbationModel):
             self.transformer_backbone._attn_implementation = "eager"
 
             # create a [1,1,S,S] mask (now S+1 if confidence token is used)
-            base = torch.eye(seq_length, device=device).view(1, seq_length, seq_length)
+            base = torch.eye(seq_length, device=device, dtype=torch.bool).view(1, 1, seq_length, seq_length)
+            
+            # Get number of attention heads from model config
+            num_heads = self.transformer_backbone.config.num_attention_heads
 
             # repeat out to [B,H,S,S]
-            attn_mask = base.repeat(batch_size, 1, 1)
+            attn_mask = base.repeat(batch_size, num_heads, 1, 1)
 
             outputs = self.transformer_backbone(inputs_embeds=seq_input, attention_mask=attn_mask)
             transformer_output = outputs.last_hidden_state


### PR DESCRIPTION
- Fixed RuntimeError: "bitwise_and_cuda" not implemented for 'Float' by changing attention mask dtype from float to bool
  - Resolved tensor dimension mismatch error by correcting attention mask shape from [B, S, S] to [B, H, S, S] where H is the number of attention heads
  - Added dynamic retrieval of attention head count from transformer model configuration instead of hardcoding
  - Ensures compatibility with PyTorch's scaled dot product attention mechanism when mask_attn=True is enabled
  - Maintains backward compatibility with existing mask_attn=False behavior