### PR TITLE
fix: Enable using control cells for context mean baseline for zero shot heldout cell types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arc-state"
-version = "0.9.28"
+version = "0.9.31"
 description = "State is a machine learning model that predicts cellular perturbation response across diverse contexts."
 readme = "README.md"
 authors = [

--- a/src/state/_cli/_tx/_train.py
+++ b/src/state/_cli/_tx/_train.py
@@ -264,16 +264,6 @@ def run_tx_train(cfg: DictConfig):
     if "log_every_n_steps" in cfg["training"]:
         trainer_kwargs["log_every_n_steps"] = cfg["training"]["log_every_n_steps"]
 
-    # If it's SimpleSum, override to do exactly 1 epoch, ignoring `max_steps`.
-    if (
-        cfg["model"]["name"].lower() == "celltypemean"
-        or cfg["model"]["name"].lower() == "globalsimplesum"
-        or cfg["model"]["name"].lower() == "perturb_mean"
-        or cfg["model"]["name"].lower() == "context_mean"
-    ):
-        trainer_kwargs["max_epochs"] = 1  # do exactly one epoch
-        # delete max_steps to avoid conflicts
-        del trainer_kwargs["max_steps"]
 
     # Build trainer
     print(f"Building trainer with kwargs: {trainer_kwargs}")


### PR DESCRIPTION
  ## Changes

  - Enhanced context mean model: Modified context mean baseline to use control cell averages as fallback when no perturbations exist for specific cell types in zero-shot scenarios
  - Removed training constraints: Eliminated hardcoded max_epochs=1 constraint for baseline models (celltypemean, globalsimplesum, perturb_mean, context_mean)