### PR TITLE
Fix bidirectional attention in Llama backbone

### DIFF
--- a/src/state/configs/model/state.yaml
+++ b/src/state/configs/model/state.yaml
@@ -25,6 +25,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 2784

--- a/src/state/configs/model/state_lg.yaml
+++ b/src/state/configs/model/state_lg.yaml
@@ -26,6 +26,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 5952

--- a/src/state/configs/model/state_sm.yaml
+++ b/src/state/configs/model/state_sm.yaml
@@ -26,6 +26,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 2688

--- a/src/state/configs/model/tahoe_best.yaml
+++ b/src/state/configs/model/tahoe_best.yaml
@@ -24,6 +24,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 4416

--- a/src/state/configs/model/tahoe_llama_212693232.yaml
+++ b/src/state/configs/model/tahoe_llama_212693232.yaml
@@ -26,6 +26,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 5952

--- a/src/state/configs/model/tahoe_llama_62089464.yaml
+++ b/src/state/configs/model/tahoe_llama_62089464.yaml
@@ -24,6 +24,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 2784

--- a/src/state/tx/models/state_transition.py
+++ b/src/state/tx/models/state_transition.py
@@ -442,11 +442,10 @@ class StateTransitionPerturbationModel(PerturbationModel):
             # repeat out to [B,H,S,S]
             attn_mask = base.repeat(batch_size, num_heads, 1, 1)
 
-            outputs = self.transformer_backbone(inputs_embeds=seq_input, attention_mask=attn_mask, output_attentions=True)
+            outputs = self.transformer_backbone(inputs_embeds=seq_input, attention_mask=attn_mask)
             transformer_output = outputs.last_hidden_state
         else:
-            attn_mask = torch.zeros((64, 1, 257, 257), dtype=torch.bool, device=seq_input.device)
-            outputs = self.transformer_backbone(inputs_embeds=seq_input, output_attentions=True, attention_mask=attn_mask)
+            outputs = self.transformer_backbone(inputs_embeds=seq_input)
             transformer_output = outputs.last_hidden_state
 
         # Extract outputs accounting for optional prepended batch token and optional confidence token at the end

--- a/src/state/tx/models/utils.py
+++ b/src/state/tx/models/utils.py
@@ -261,8 +261,16 @@ class LlamaBidirectionalModel(LlamaModel):
         
         # If no attention_mask is provided, create an all-ones mask (no masking)
         # This ensures bidirectional attention with correct device/dtype
-        
-            
+        if not attention_mask:
+            # Get batch size (B) and sequence length (S) from input_embeds if available, else from input_ids.
+            # If neither is available, fall back to attention_mask=None and log a warning.
+            B = None
+            S = None
+            if inputs_embeds is not None:
+                B, S = inputs_embeds.size(0), inputs_embeds.size(1)
+            if not attention_mask and B and S:
+                attention_mask = torch.ones((B, S), dtype=torch.bool, device=inputs_embeds.device if inputs_embeds is not None else input_ids.device)
+            attention_mask = torch.zeros((B, 1, S, S), dtype=torch.bool, device=inputs_embeds.device)
 
         return super().forward(
             input_ids=input_ids,

--- a/src/state/tx/models/utils.py
+++ b/src/state/tx/models/utils.py
@@ -99,6 +99,8 @@ def get_loss_fn(loss: Union[str, nn.Module]) -> nn.Module:
 
 
 def get_transformer_backbone(key, kwargs) -> PreTrainedModel:
+    kwargs = dict(kwargs or {})
+
     if key == "GPT2":
         config = GPT2Config(**kwargs)
         model = GPT2BidirectionalModel(config)
@@ -110,9 +112,14 @@ def get_transformer_backbone(key, kwargs) -> PreTrainedModel:
         model.wte.weight.zero_()
 
         model_dim = config.n_embd
-    elif key == "llama":        
+    elif key == "llama":
+        bidirectional_attention = bool(kwargs.pop("bidirectional_attention", False))
+
         config = LlamaConfig(**kwargs)
-        model = LlamaBidirectionalModel(config)
+        if bidirectional_attention:
+            model = LlamaBidirectionalModel(config)
+        else:
+            model = LlamaModel(config)
         model_dim = config.hidden_size
 
         model.embed_tokens.weight.requires_grad = False

--- a/src/state/tx/models/utils.py
+++ b/src/state/tx/models/utils.py
@@ -269,7 +269,7 @@ class LlamaBidirectionalModel(LlamaModel):
             if inputs_embeds is not None:
                 B, S = inputs_embeds.size(0), inputs_embeds.size(1)
             if not attention_mask and B and S:
-                attention_mask = torch.zeros((B, 1, S, S), dtype=torch.bool, device=inputs_embeds.device)
+                attention_mask = torch.ones((B, 1, S, S), dtype=torch.float, device=inputs_embeds.device)
 
         return super().forward(
             input_ids=input_ids,

--- a/src/state/tx/models/utils.py
+++ b/src/state/tx/models/utils.py
@@ -110,7 +110,7 @@ def get_transformer_backbone(key, kwargs) -> PreTrainedModel:
         model.wte.weight.zero_()
 
         model_dim = config.n_embd
-    elif key == "llama":
+    elif key == "llama":        
         config = LlamaConfig(**kwargs)
         model = LlamaBidirectionalModel(config)
         model_dim = config.hidden_size
@@ -196,19 +196,18 @@ class NoRoPE(nn.Module):
     of shape (batch_size, seq_len, head_dim), so rotary has no effect.
     """
 
-    def __init__(self, num_attention_heads: int, hidden_size: int):
+    def __init__(self, head_dim: int):
         super().__init__()
-        self.num_heads = num_attention_heads
-        self.hidden_size = hidden_size
+        self.head_dim = head_dim
 
     def forward(self, hidden_states: torch.Tensor, position_ids: torch.LongTensor):
         # hidden_states: (batch_size, seq_len, hidden_dim)
-        batch_size, seq_len, hidden_dim = hidden_states.shape
+        batch_size, seq_len, _hidden_dim = hidden_states.shape
 
         # Create cos = ones, sin = zeros
         #   shape --> (batch_size, seq_len, head_dim)
-        cos = hidden_states.new_ones(batch_size, seq_len, self.num_heads)
-        sin = hidden_states.new_zeros(batch_size, seq_len, self.num_heads)
+        cos = hidden_states.new_ones(batch_size, seq_len, self.head_dim)
+        sin = hidden_states.new_zeros(batch_size, seq_len, self.head_dim)
         return cos, sin
 
 
@@ -222,9 +221,15 @@ class LlamaBidirectionalModel(LlamaModel):
         super().__init__(config)
 
         self.rotary_emb = NoRoPE(
-            num_attention_heads=config.head_dim,
-            hidden_size=config.hidden_size,
+            head_dim=config.head_dim,
         )
+        
+        # Explicitly disable causal attention
+        self.config.is_causal = False
+        # force every layer to be non-causal
+        for layer in self.layers:
+            if hasattr(layer, "self_attn"):
+                layer.self_attn.is_causal = False   # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]
 
     def _update_causal_mask(
         self,
@@ -235,7 +240,7 @@ class LlamaBidirectionalModel(LlamaModel):
         output_attentions: bool = False,
     ):
         # By returning None, we disable any causal‐(look‐ahead) masking.
-        # The only mask that remains is whatever “attention_mask” the user has passed
+        # The only mask that remains is whatever "attention_mask" the user has passed
         # (e.g. padding‐mask), which will be handled by Flash/SDPA internally as non‐causal.
         return None
 
@@ -253,6 +258,11 @@ class LlamaBidirectionalModel(LlamaModel):
         **flash_attn_kwargs,
     ):
         flash_attn_kwargs["is_causal"] = False
+        
+        # If no attention_mask is provided, create an all-ones mask (no masking)
+        # This ensures bidirectional attention with correct device/dtype
+        
+            
 
         return super().forward(
             input_ids=input_ids,

--- a/src/state/tx/models/utils.py
+++ b/src/state/tx/models/utils.py
@@ -269,8 +269,7 @@ class LlamaBidirectionalModel(LlamaModel):
             if inputs_embeds is not None:
                 B, S = inputs_embeds.size(0), inputs_embeds.size(1)
             if not attention_mask and B and S:
-                attention_mask = torch.ones((B, S), dtype=torch.bool, device=inputs_embeds.device if inputs_embeds is not None else input_ids.device)
-            attention_mask = torch.zeros((B, 1, S, S), dtype=torch.bool, device=inputs_embeds.device)
+                attention_mask = torch.zeros((B, 1, S, S), dtype=torch.bool, device=inputs_embeds.device)
 
         return super().forward(
             input_ids=input_ids,

--- a/src/state/tx/models/utils.py
+++ b/src/state/tx/models/utils.py
@@ -247,7 +247,7 @@ class LlamaBidirectionalModel(LlamaModel):
     def forward(
         self,
         input_ids: torch.LongTensor = None,
-        attention_mask: torch.Tensor = None,
+        attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor = None,
         past_key_values=None,
         inputs_embeds: torch.FloatTensor = None,
@@ -261,14 +261,14 @@ class LlamaBidirectionalModel(LlamaModel):
         
         # If no attention_mask is provided, create an all-ones mask (no masking)
         # This ensures bidirectional attention with correct device/dtype
-        if not attention_mask:
+        if attention_mask is None:
             # Get batch size (B) and sequence length (S) from input_embeds if available, else from input_ids.
             # If neither is available, fall back to attention_mask=None and log a warning.
             B = None
             S = None
             if inputs_embeds is not None:
                 B, S = inputs_embeds.size(0), inputs_embeds.size(1)
-            if not attention_mask and B and S:
+            if B and S:
                 attention_mask = torch.ones((B, 1, S, S), dtype=torch.float, device=inputs_embeds.device)
 
         return super().forward(

--- a/tests/test_bidirectional_models.py
+++ b/tests/test_bidirectional_models.py
@@ -1,0 +1,305 @@
+"""Tests for bidirectional attention models (Llama and GPT2)."""
+
+import pytest
+import torch
+from transformers import LlamaConfig, LlamaModel
+
+from state.tx.models.utils import LlamaBidirectionalModel
+
+
+@pytest.fixture
+def small_llama_config():
+    """Create a small Llama config for testing."""
+    return LlamaConfig(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+    )
+
+
+def test_llama_bidirectional_config_is_non_causal(small_llama_config):
+    """Test that LlamaBidirectionalModel sets is_causal to False."""
+    model = LlamaBidirectionalModel(small_llama_config)
+    
+    # Check that the model config is non-causal
+    assert model.config.is_causal is False
+    
+    # Check that all attention layers are non-causal
+    for layer in model.layers:
+        if hasattr(layer, "self_attn"):
+            assert layer.self_attn.is_causal is False  # type: ignore
+
+
+def test_llama_bidirectional_update_causal_mask_returns_none(small_llama_config):
+    """Test that _update_causal_mask returns None, disabling causal masking."""
+    model = LlamaBidirectionalModel(small_llama_config)
+    
+    # Create dummy inputs
+    batch_size, seq_len = 2, 8
+    attention_mask = torch.ones(batch_size, seq_len)
+    input_tensor = torch.randn(batch_size, seq_len, small_llama_config.hidden_size)
+    cache_position = torch.arange(seq_len)
+    
+    # Call _update_causal_mask
+    result = model._update_causal_mask(
+        attention_mask=attention_mask,
+        input_tensor=input_tensor,
+        cache_position=cache_position,
+        past_key_values=None,
+        output_attentions=False,
+    )
+    
+    # Should return None (no causal masking)
+    assert result is None
+
+
+def test_llama_bidirectional_attention_vs_causal(small_llama_config):
+    """
+    Test that bidirectional attention produces different outputs than causal attention.
+    
+    This is the key test: in bidirectional attention, later tokens should affect
+    earlier token representations, which doesn't happen in causal attention.
+    """
+    torch.manual_seed(42)
+    
+    # Create both bidirectional and standard (causal) models
+    bidirectional_model = LlamaBidirectionalModel(small_llama_config)
+    causal_model = LlamaModel(small_llama_config)
+    
+    # Copy weights from bidirectional to causal to ensure same initialization
+    causal_model.load_state_dict(bidirectional_model.state_dict(), strict=False)
+    
+    # Create input
+    batch_size, seq_len = 2, 8
+    inputs_embeds = torch.randn(batch_size, seq_len, small_llama_config.hidden_size)
+    
+    # Set models to eval mode
+    bidirectional_model.eval()
+    causal_model.eval()
+    
+    with torch.no_grad():
+        # Get outputs from bidirectional model
+        bidirectional_output = bidirectional_model(inputs_embeds=inputs_embeds)
+        
+        # Get outputs from causal model
+        causal_output = causal_model(inputs_embeds=inputs_embeds)
+    
+    # The outputs should be different because bidirectional allows all tokens
+    # to attend to each other, while causal only allows attending to past tokens
+    assert not torch.allclose(
+        bidirectional_output.last_hidden_state,
+        causal_output.last_hidden_state,
+        atol=1e-5
+    ), "Bidirectional and causal outputs should differ"
+
+
+def test_llama_bidirectional_future_tokens_affect_past(small_llama_config):
+    """
+    Test that future tokens affect past token representations in bidirectional model.
+    
+    This is the core property of bidirectional attention: changing a future token
+    should change the representation of past tokens.
+    """
+    torch.manual_seed(42)
+    
+    model = LlamaBidirectionalModel(small_llama_config)
+    model.eval()
+    
+    batch_size, seq_len = 1, 6
+    hidden_size = small_llama_config.hidden_size
+    
+    # Create two inputs that differ only in the last token
+    inputs_embeds_1 = torch.randn(batch_size, seq_len, hidden_size)
+    inputs_embeds_2 = inputs_embeds_1.clone()
+    
+    # Modify only the last token embedding in the second input
+    inputs_embeds_2[:, -1, :] = torch.randn(batch_size, hidden_size)
+    
+    with torch.no_grad():
+        output_1 = model(inputs_embeds=inputs_embeds_1)
+        output_2 = model(inputs_embeds=inputs_embeds_2)
+    
+    # Check that the first tokens' representations differ between the two inputs
+    # This demonstrates that the last token (future) affects the first token (past)
+    first_token_repr_1 = output_1.last_hidden_state[:, 0, :]
+    first_token_repr_2 = output_2.last_hidden_state[:, 0, :]
+    
+    assert not torch.allclose(first_token_repr_1, first_token_repr_2, atol=1e-5), \
+        "First token representation should change when last token changes (bidirectional attention)"
+
+
+def test_llama_bidirectional_first_token_differs_across_batch(small_llama_config):
+    """
+    Test that first token representations differ across batch when sequences differ.
+    
+    This is a critical test for bidirectional attention: in causal attention,
+    the first token can only attend to itself, so if all sequences have the same
+    first token, they would produce identical first token representations.
+    
+    In bidirectional attention, the first token attends to all tokens in the sequence,
+    so different sequences should produce different first token representations even
+    when the first tokens themselves are identical.
+    """
+    torch.manual_seed(42)
+    
+    model = LlamaBidirectionalModel(small_llama_config)
+    model.eval()
+    
+    batch_size, seq_len = 4, 8
+    hidden_size = small_llama_config.hidden_size
+    
+    # Create a batch where ALL sequences have the SAME first token embedding
+    # but DIFFERENT subsequent tokens
+    inputs_embeds = torch.randn(batch_size, seq_len, hidden_size)
+    
+    # Make the first token identical across all sequences
+    shared_first_token = torch.randn(1, hidden_size)
+    inputs_embeds[:, 0, :] = shared_first_token
+    
+    with torch.no_grad():
+        output = model(inputs_embeds=inputs_embeds)
+    
+    # Extract first token representations for all sequences
+    first_token_reprs = output.last_hidden_state[:, 0, :]  # Shape: (batch_size, hidden_size)
+    
+    # In bidirectional attention, these should all be DIFFERENT
+    # because each attends to different subsequent tokens
+    # Check that not all first tokens are the same
+    for i in range(batch_size):
+        for j in range(i + 1, batch_size):
+            assert not torch.allclose(
+                first_token_reprs[i], 
+                first_token_reprs[j], 
+                atol=1e-5
+            ), f"First token representations for sequences {i} and {j} should differ in bidirectional attention"
+    
+    # Additional check: variance across batch should be substantial
+    variance_per_dim = torch.var(first_token_reprs, dim=0)
+    mean_variance = variance_per_dim.mean()
+    assert mean_variance > 1e-4, \
+        "First token representations should have substantial variance across batch in bidirectional attention"
+
+
+def test_llama_bidirectional_symmetric_position_influence(small_llama_config):
+    """
+    Test that in bidirectional attention, position i affects position j 
+    as much as position j affects position i (roughly symmetric).
+    """
+    torch.manual_seed(42)
+    
+    model = LlamaBidirectionalModel(small_llama_config)
+    model.eval()
+    
+    batch_size, seq_len = 1, 4
+    hidden_size = small_llama_config.hidden_size
+    
+    # Create base input
+    base_input = torch.randn(batch_size, seq_len, hidden_size)
+    
+    # Modify position 0 and see effect on position 2
+    input_modify_0 = base_input.clone()
+    input_modify_0[:, 0, :] = torch.randn(batch_size, hidden_size)
+    
+    # Modify position 2 and see effect on position 0
+    input_modify_2 = base_input.clone()
+    input_modify_2[:, 2, :] = torch.randn(batch_size, hidden_size)
+    
+    with torch.no_grad():
+        output_base = model(inputs_embeds=base_input)
+        output_modify_0 = model(inputs_embeds=input_modify_0)
+        output_modify_2 = model(inputs_embeds=input_modify_2)
+    
+    # Calculate how much position 2 changes when position 0 changes
+    effect_0_on_2 = torch.norm(
+        output_modify_0.last_hidden_state[:, 2, :] - output_base.last_hidden_state[:, 2, :]
+    )
+    
+    # Calculate how much position 0 changes when position 2 changes
+    effect_2_on_0 = torch.norm(
+        output_modify_2.last_hidden_state[:, 0, :] - output_base.last_hidden_state[:, 0, :]
+    )
+    
+    # In bidirectional attention, these effects should both be non-zero
+    # (demonstrating mutual influence, unlike in causal attention)
+    assert effect_0_on_2 > 0.01, "Position 0 should affect position 2"
+    assert effect_2_on_0 > 0.01, "Position 2 should affect position 0"
+
+
+def test_llama_bidirectional_forward_with_input_ids(small_llama_config):
+    """Test that forward pass works with input_ids."""
+    model = LlamaBidirectionalModel(small_llama_config)
+    model.eval()
+    
+    batch_size, seq_len = 2, 10
+    input_ids = torch.randint(0, small_llama_config.vocab_size, (batch_size, seq_len))
+    
+    with torch.no_grad():
+        output = model(input_ids=input_ids)
+    
+    # Check output shape
+    assert output.last_hidden_state.shape == (batch_size, seq_len, small_llama_config.hidden_size)
+
+
+def test_llama_bidirectional_forward_with_attention_mask(small_llama_config):
+    """Test that forward pass respects attention mask for padding."""
+    model = LlamaBidirectionalModel(small_llama_config)
+    model.eval()
+    
+    batch_size, seq_len = 2, 10
+    hidden_size = small_llama_config.hidden_size
+    inputs_embeds = torch.randn(batch_size, seq_len, hidden_size)
+    
+    # Create attention mask: first sequence has padding at positions 8-9
+    attention_mask = torch.ones(batch_size, seq_len)
+    attention_mask[0, 8:] = 0  # Mask out last 2 positions for first sequence
+    
+    with torch.no_grad():
+        output = model(inputs_embeds=inputs_embeds, attention_mask=attention_mask)
+    
+    # Check that output shape is correct
+    assert output.last_hidden_state.shape == (batch_size, seq_len, hidden_size)
+
+
+def test_llama_bidirectional_is_causal_false_in_forward(small_llama_config):
+    """Test that is_causal=False is passed in flash_attn_kwargs during forward."""
+    model = LlamaBidirectionalModel(small_llama_config)
+    model.eval()
+    
+    batch_size, seq_len = 1, 8
+    inputs_embeds = torch.randn(batch_size, seq_len, small_llama_config.hidden_size)
+    
+    # Monkey-patch the parent's forward to capture flash_attn_kwargs
+    original_forward = LlamaModel.forward
+    captured_kwargs = {}
+    
+    def capture_forward(self, **kwargs):
+        captured_kwargs.update(kwargs)
+        return original_forward(self, **kwargs)
+    
+    LlamaModel.forward = capture_forward  # type: ignore
+    
+    try:
+        with torch.no_grad():
+            model(inputs_embeds=inputs_embeds)
+        
+        # Check that is_causal was set to False
+        assert "is_causal" in captured_kwargs
+        assert captured_kwargs["is_causal"] is False
+    finally:
+        # Restore original forward
+        LlamaModel.forward = original_forward
+
+
+def test_llama_bidirectional_no_rope(small_llama_config):
+    """Test that NoRoPE is used instead of standard rotary embeddings."""
+    from state.tx.models.utils import NoRoPE
+    
+    model = LlamaBidirectionalModel(small_llama_config)
+    
+    # Check that rotary_emb is an instance of NoRoPE
+    assert isinstance(model.rotary_emb, NoRoPE)
+

--- a/tests/test_bidirectional_models.py
+++ b/tests/test_bidirectional_models.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from transformers import LlamaConfig, LlamaModel
 
-from state.tx.models.utils import LlamaBidirectionalModel
+from state.tx.models.utils import LlamaBidirectionalModel, get_transformer_backbone
 
 
 @pytest.fixture
@@ -55,6 +55,44 @@ def test_llama_bidirectional_update_causal_mask_returns_none(small_llama_config)
     
     # Should return None (no causal masking)
     assert result is None
+
+
+def test_get_transformer_backbone_llama_is_causal_by_default():
+    """get_transformer_backbone should return a causal LlamaModel unless opted in."""
+
+    kwargs = {
+        "vocab_size": 100,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "max_position_embeddings": 32,
+    }
+
+    model, model_dim = get_transformer_backbone("llama", kwargs)
+
+    assert type(model) is LlamaModel
+    assert model_dim == kwargs["hidden_size"]
+
+
+def test_get_transformer_backbone_llama_bidirectional_flag():
+    """Setting bidirectional_attention=True should opt into bidirectional Llama."""
+
+    kwargs = {
+        "vocab_size": 100,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "max_position_embeddings": 32,
+        "bidirectional_attention": True,
+    }
+
+    model, _ = get_transformer_backbone("llama", kwargs)
+
+    assert isinstance(model, LlamaBidirectionalModel)
 
 
 def test_llama_bidirectional_attention_vs_causal(small_llama_config):


### PR DESCRIPTION
This PR fixes a bug where we were not correctly overriding Llama's default behavior of using causal masking in attention. The fix is to pass in an attention mask of ones, which tells Llama to not use causal masking.

I've added tests.