### PR TITLE
Make Llama bidirectional attention opt-in

### DIFF
--- a/src/state/configs/model/state.yaml
+++ b/src/state/configs/model/state.yaml
@@ -25,6 +25,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 2784

--- a/src/state/configs/model/state_lg.yaml
+++ b/src/state/configs/model/state_lg.yaml
@@ -26,6 +26,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 5952

--- a/src/state/configs/model/state_sm.yaml
+++ b/src/state/configs/model/state_sm.yaml
@@ -26,6 +26,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 2688

--- a/src/state/configs/model/tahoe_best.yaml
+++ b/src/state/configs/model/tahoe_best.yaml
@@ -24,6 +24,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 4416

--- a/src/state/configs/model/tahoe_llama_212693232.yaml
+++ b/src/state/configs/model/tahoe_llama_212693232.yaml
@@ -26,6 +26,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 5952

--- a/src/state/configs/model/tahoe_llama_62089464.yaml
+++ b/src/state/configs/model/tahoe_llama_62089464.yaml
@@ -24,6 +24,7 @@ kwargs:
   init_from: null
   transformer_backbone_key: llama
   transformer_backbone_kwargs:
+      bidirectional_attention: false
       max_position_embeddings: ${model.kwargs.cell_set_len}
       hidden_size: ${model.kwargs.hidden_dim}
       intermediate_size: 2784

--- a/src/state/tx/models/utils.py
+++ b/src/state/tx/models/utils.py
@@ -99,6 +99,8 @@ def get_loss_fn(loss: Union[str, nn.Module]) -> nn.Module:
 
 
 def get_transformer_backbone(key, kwargs) -> PreTrainedModel:
+    kwargs = dict(kwargs or {})
+
     if key == "GPT2":
         config = GPT2Config(**kwargs)
         model = GPT2BidirectionalModel(config)
@@ -110,9 +112,14 @@ def get_transformer_backbone(key, kwargs) -> PreTrainedModel:
         model.wte.weight.zero_()
 
         model_dim = config.n_embd
-    elif key == "llama":        
+    elif key == "llama":
+        bidirectional_attention = bool(kwargs.pop("bidirectional_attention", False))
+
         config = LlamaConfig(**kwargs)
-        model = LlamaBidirectionalModel(config)
+        if bidirectional_attention:
+            model = LlamaBidirectionalModel(config)
+        else:
+            model = LlamaModel(config)
         model_dim = config.hidden_size
 
         model.embed_tokens.weight.requires_grad = False

--- a/tests/test_bidirectional_models.py
+++ b/tests/test_bidirectional_models.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from transformers import LlamaConfig, LlamaModel
 
-from state.tx.models.utils import LlamaBidirectionalModel
+from state.tx.models.utils import LlamaBidirectionalModel, get_transformer_backbone
 
 
 @pytest.fixture
@@ -55,6 +55,44 @@ def test_llama_bidirectional_update_causal_mask_returns_none(small_llama_config)
     
     # Should return None (no causal masking)
     assert result is None
+
+
+def test_get_transformer_backbone_llama_is_causal_by_default():
+    """get_transformer_backbone should return a causal LlamaModel unless opted in."""
+
+    kwargs = {
+        "vocab_size": 100,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "max_position_embeddings": 32,
+    }
+
+    model, model_dim = get_transformer_backbone("llama", kwargs)
+
+    assert type(model) is LlamaModel
+    assert model_dim == kwargs["hidden_size"]
+
+
+def test_get_transformer_backbone_llama_bidirectional_flag():
+    """Setting bidirectional_attention=True should opt into bidirectional Llama."""
+
+    kwargs = {
+        "vocab_size": 100,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "max_position_embeddings": 32,
+        "bidirectional_attention": True,
+    }
+
+    model, _ = get_transformer_backbone("llama", kwargs)
+
+    assert isinstance(model, LlamaBidirectionalModel)
 
 
 def test_llama_bidirectional_attention_vs_causal(small_llama_config):


### PR DESCRIPTION
## Summary
- add a `bidirectional_attention` switch to Llama transformer backbone configs and default it to causal attention
- only instantiate the bidirectional Llama wrapper when the flag is enabled and extend tests to cover the new behavior

## Testing
- PYTHONPATH=src pytest tests/test_bidirectional_models.py


------
https://chatgpt.com/codex/tasks/task_e_68dd6488578c8325a774338487c736d0