### PR TITLE
Add toggle to disable perturbation encoder in state transition model

### DIFF
--- a/src/state/configs/model/state.yaml
+++ b/src/state/configs/model/state.yaml
@@ -21,6 +21,7 @@ kwargs:
   nb_decoder: False
   mask_attn: False
   use_effect_gating_token: False
+  zero_perturbation_encoder: False
   distributional_loss: energy
   init_from: null
   transformer_backbone_key: llama

--- a/src/state/configs/model/state_lg.yaml
+++ b/src/state/configs/model/state_lg.yaml
@@ -21,6 +21,7 @@ kwargs:
   nb_decoder: False
   mask_attn: False
   use_effect_gating_token: False
+  zero_perturbation_encoder: False
   use_basal_projection: False
   distributional_loss: energy
   init_from: null

--- a/src/state/configs/model/state_sm.yaml
+++ b/src/state/configs/model/state_sm.yaml
@@ -20,6 +20,7 @@ kwargs:
   nb_decoder: False
   mask_attn: False
   use_effect_gating_token: False
+  zero_perturbation_encoder: False
   use_basal_projection: False
   distributional_loss: energy
   gene_decoder_bool: False

--- a/src/state/tx/models/state_transition.py
+++ b/src/state/tx/models/state_transition.py
@@ -182,6 +182,7 @@ class StateTransitionPerturbationModel(PerturbationModel):
             raise ValueError(f"Unknown loss function: {loss_name}")
 
         self.use_basal_projection = kwargs.get("use_basal_projection", True)
+        self.zero_perturbation_encoder = kwargs.get("zero_perturbation_encoder", False)
 
         # Build the underlying neural OT network
         self._build_networks(lora_cfg=kwargs.get("lora", None))
@@ -392,6 +393,8 @@ class StateTransitionPerturbationModel(PerturbationModel):
 
         # Shape: [B, S, input_dim]
         pert_embedding = self.encode_perturbation(pert)
+        if self.zero_perturbation_encoder:
+            pert_embedding = torch.zeros_like(pert_embedding)
         control_cells = self.encode_basal_expression(basal)
 
         # Add encodings in input_dim space, then project to hidden_dim


### PR DESCRIPTION
## Summary
- add a `zero_perturbation_encoder` option to the state transition model to zero out perturbation inputs
- surface the new flag in state model configs so it can be toggled for ablation experiments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efdb4c29988325abe380738fdcd336