### PR TITLE
update MetricsEvaluator calls for cell-eval 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "geomloss>=0.2.6",
     "transformers>=4.52.3",
     "peft>=0.11.0",
-    "cell-eval>=0.6.8",
+    "cell-eval>=0.7.0",
     "ipykernel>=6.30.1",
     "scipy>=1.15.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arc-state"
-version = "0.10.4"
+version = "0.10.5"
 description = "State is a machine learning model that predicts cellular perturbation response across diverse contexts."
 readme = "README.md"
 authors = [

--- a/src/state/_cli/_tx/_predict.py
+++ b/src/state/_cli/_tx/_predict.py
@@ -578,7 +578,6 @@ def run_tx_predict(args: ap.ArgumentParser):
                     outdir=results_dir,
                     prefix=ct,
                     pdex_kwargs=pdex_kwargs,
-                    batch_size=2048,
                 )
                 evaluator.compute(
                     profile=args.profile,
@@ -812,7 +811,6 @@ def run_tx_predict(args: ap.ArgumentParser):
                 outdir=results_dir,
                 prefix=ct,
                 pdex_kwargs=pdex_kwargs,
-                batch_size=2048,
             )
 
             evaluator.compute(


### PR DESCRIPTION
cell-eval 0.7.0 removed the `batch_size` parameter from `MetricsEvaluator.__init__`. This PR removes the `batch_size=2048` argument from both `MetricsEvaluator` instantiations in `_predict.py` and bumps the version constraint in `pyproject.toml` to `>=0.7.0`.