### PR TITLE
guard torch.cuda.synchronize for CPU/MPS eval paths

### DIFF
--- a/src/state/_cli/_emb/_eval.py
+++ b/src/state/_cli/_emb/_eval.py
@@ -118,7 +118,7 @@ def run_emb_eval(args):
     with torch.no_grad():
         with torch.autocast(device_type=device_type, dtype=precision):
             for batch in tqdm(dataloader, desc="Processing batches"):
-                if torch.cuda.is_available():
+                if device_type == "cuda":
                     torch.cuda.synchronize()
                     torch.cuda.empty_cache()
 

--- a/src/state/_cli/_emb/_eval.py
+++ b/src/state/_cli/_emb/_eval.py
@@ -118,8 +118,9 @@ def run_emb_eval(args):
     with torch.no_grad():
         with torch.autocast(device_type=device_type, dtype=precision):
             for batch in tqdm(dataloader, desc="Processing batches"):
-                torch.cuda.synchronize()
-                torch.cuda.empty_cache()
+                if torch.cuda.is_available():
+                    torch.cuda.synchronize()
+                    torch.cuda.empty_cache()
 
                 # Compute embeddings
                 _, _, _, emb, ds_emb = model._compute_embedding_for_batch(batch)

--- a/src/state/emb/nn/eval_utils.py
+++ b/src/state/emb/nn/eval_utils.py
@@ -76,7 +76,8 @@ def evaluate_de(model, cfg, device=None, logger=print):
     pred_exp = model._predict_exp_for_adata(
         tmp_adata, cfg["validations"]["diff_exp"]["dataset_name"], cfg["validations"]["diff_exp"]["obs_pert_col"]
     )
-    torch.cuda.synchronize()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
     de_metrics = compute_gene_overlap_cross_pert(
         pred_exp, true_top_genes, k=cfg["validations"]["diff_exp"]["top_k_rank"]
     )


### PR DESCRIPTION
Two unguarded `torch.cuda.synchronize()` calls (one paired with `torch.cuda.empty_cache()`) currently raise `RuntimeError: No CUDA GPUs are available` when running the eval paths on a CPU- or MPS-only machine, even when the model itself can run on CPU:

- `src/state/_cli/_emb/_eval.py:121-122` — inside the embedding eval batch loop
- `src/state/emb/nn/eval_utils.py:79` — between `_predict_exp_for_adata` and the DE gene-overlap metric

This wraps each in `if torch.cuda.is_available():`, matching the existing pattern already used in `src/state/tx/callbacks/model_flops_utilization.py` (lines 131 and 148).

Net change: 5 lines across 2 files. No behavior change on CUDA hosts; eval now runs on CPU/MPS hosts that previously crashed.