### PR TITLE
Add --stream-adatas: memory-bounded h5ad streaming for tx predict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arc-state"
-version = "0.11.1"
+version = "0.11.2"
 description = "State is a machine learning model that predicts cellular perturbation response across diverse contexts."
 readme = "README.md"
 authors = [

--- a/src/state/_cli/_tx/_predict.py
+++ b/src/state/_cli/_tx/_predict.py
@@ -73,7 +73,7 @@ def add_arguments_predict(parser: ap.ArgumentParser):
         help=(
             "Stream per-batch predictions directly to adata_pred.h5ad / adata_real.h5ad on "
             "disk, bounding host memory to ~one batch instead of materializing the full "
-            "(n_cells, n_genes) matrices. Implies --predict-only (in-process cell-eval is "
+            "(n_cells, n_genes) matrices. Requires --predict-only (in-process cell-eval is "
             "skipped); score the written h5ads downstream."
         ),
     )

--- a/src/state/_cli/_tx/_predict.py
+++ b/src/state/_cli/_tx/_predict.py
@@ -130,11 +130,6 @@ def run_tx_predict(args: ap.ArgumentParser):
         logger.warning("Both --predict-only and --skip-adatas were set; no prediction artifacts will be written.")
 
     validate_stream_adatas_args(args)
-    if args.stream_adatas and args.pseudobulk:
-        logger.warning(
-            "--stream-adatas ignored: --pseudobulk already aggregates in a streaming, "
-            "low-memory fashion."
-        )
 
     def run_test_time_finetune(model, dataloader, ft_epochs, control_pert, device):
         """

--- a/src/state/_cli/_tx/_predict.py
+++ b/src/state/_cli/_tx/_predict.py
@@ -68,6 +68,17 @@ def add_arguments_predict(parser: ap.ArgumentParser):
     )
 
     parser.add_argument(
+        "--stream-adatas",
+        action="store_true",
+        help=(
+            "Stream per-batch predictions directly to adata_pred.h5ad / adata_real.h5ad on "
+            "disk, bounding host memory to ~one batch instead of materializing the full "
+            "(n_cells, n_genes) matrices. Implies --predict-only (in-process cell-eval is "
+            "skipped); score the written h5ads downstream."
+        ),
+    )
+
+    parser.add_argument(
         "--shared-only",
         action="store_true",
         help=("If set, restrict predictions/evaluation to perturbations shared between train and test (train ∩ test)."),
@@ -108,6 +119,7 @@ def run_tx_predict(args: ap.ArgumentParser):
     from cell_load.data_modules import PerturbationDataModule
     from tqdm import tqdm
     from ._utils import normalize_batch_labels
+    from ._stream_h5ad import validate_stream_adatas_args
 
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
@@ -116,6 +128,13 @@ def run_tx_predict(args: ap.ArgumentParser):
 
     if args.predict_only and args.skip_adatas:
         logger.warning("Both --predict-only and --skip-adatas were set; no prediction artifacts will be written.")
+
+    validate_stream_adatas_args(args)
+    if args.stream_adatas and args.pseudobulk:
+        logger.warning(
+            "--stream-adatas ignored: --pseudobulk already aggregates in a streaming, "
+            "low-memory fashion."
+        )
 
     def run_test_time_finetune(model, dataloader, ft_epochs, control_pert, device):
         """

--- a/src/state/_cli/_tx/_predict.py
+++ b/src/state/_cli/_tx/_predict.py
@@ -687,11 +687,11 @@ def run_tx_predict(args: ap.ArgumentParser):
             adata_real_path, num_cells, x_dim, obsm=obsm_spec, clip=(0.0, 14.0)
         )
 
-        all_pert_names: list = []
-        all_celltypes: list = []
-        all_gem_groups: list = []
-        all_pert_barcodes: list = []
-        all_ctrl_barcodes: list = []
+        all_pert_names: list[str] = []
+        all_celltypes: list[str] = []
+        all_gem_groups: list[str] = []
+        all_pert_barcodes: list[str] = []
+        all_ctrl_barcodes: list[str] = []
 
         with torch.no_grad():
             for batch_idx, batch in enumerate(

--- a/src/state/_cli/_tx/_predict.py
+++ b/src/state/_cli/_tx/_predict.py
@@ -119,7 +119,7 @@ def run_tx_predict(args: ap.ArgumentParser):
     from cell_load.data_modules import PerturbationDataModule
     from tqdm import tqdm
     from ._utils import normalize_batch_labels
-    from ._stream_h5ad import validate_stream_adatas_args
+    from ._stream_h5ad import StreamingDenseH5ad, select_stream_payload, validate_stream_adatas_args
 
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
@@ -635,6 +635,153 @@ def run_tx_predict(args: ap.ArgumentParser):
                     else {},
                     skip_metrics=["pearson_edistance", "clustering_agreement"],
                 )
+        return
+
+    if args.stream_adatas:
+        logger.info("Streaming predictions directly to h5ad (low-memory mode).")
+        if args.eval_train_data:
+            results_dir = os.path.join(
+                args.output_dir, "eval_train_" + os.path.basename(args.checkpoint)
+            )
+        else:
+            results_dir = os.path.join(
+                args.output_dir, "eval_" + os.path.basename(args.checkpoint)
+            )
+        os.makedirs(results_dir, exist_ok=True)
+        adata_pred_path = os.path.join(results_dir, "adata_pred.h5ad")
+        adata_real_path = os.path.join(results_dir, "adata_real.h5ad")
+
+        # X width + obsm spec mirror the AnnData assembly in the in-memory path.
+        if store_raw_expression:
+            x_dim = hvg_dim if cfg["data"]["kwargs"]["output_space"] == "gene" else gene_dim
+            obsm_spec: dict[str, int] | None = {data_module.embed_key: output_dim}
+        else:
+            x_dim = output_dim
+            obsm_spec = None
+
+        # --shared-only: filter each batch to perts seen in train ∩ test.
+        shared_perts = None
+        if args.shared_only:
+            try:
+                shared_perts = set(data_module.get_shared_perturbations())
+                if not shared_perts:
+                    logger.warning(
+                        "No shared perturbations between train and test; not filtering."
+                    )
+                    shared_perts = None
+                else:
+                    logger.info(
+                        "Filtering to %d shared perturbations (train ∩ test).",
+                        len(shared_perts),
+                    )
+            except Exception as e:  # noqa: BLE001 - mirror the in-memory path's tolerance
+                logger.warning(
+                    "Failed to resolve shared perturbations (%s); not filtering.", str(e)
+                )
+                shared_perts = None
+
+        pred_writer = StreamingDenseH5ad(
+            adata_pred_path, num_cells, x_dim, obsm=obsm_spec, clip=(0.0, 14.0)
+        )
+        real_writer = StreamingDenseH5ad(
+            adata_real_path, num_cells, x_dim, obsm=obsm_spec, clip=(0.0, 14.0)
+        )
+
+        all_pert_names: list = []
+        all_celltypes: list = []
+        all_gem_groups: list = []
+        all_pert_barcodes: list = []
+        all_ctrl_barcodes: list = []
+
+        with torch.no_grad():
+            for batch_idx, batch in enumerate(
+                tqdm(test_loader, desc="Predicting (stream)", unit="batch")
+            ):
+                batch = {
+                    k: (v.to(device) if isinstance(v, torch.Tensor) else v)
+                    for k, v in batch.items()
+                }
+                batch_preds = model.predict_step(batch, batch_idx, padded=False)
+                batch_size = batch_preds["preds"].shape[0]
+
+                # Per-cell metadata (same sources as the in-memory loop).
+                if isinstance(batch_preds["pert_name"], list):
+                    pert_names = list(batch_preds["pert_name"])
+                else:
+                    pert_names = [batch_preds["pert_name"]]
+                if isinstance(batch_preds["celltype_name"], list):
+                    celltypes = list(batch_preds["celltype_name"])
+                else:
+                    celltypes = [batch_preds["celltype_name"]]
+                gem_groups = get_batch_labels(
+                    (
+                        batch.get("batch_name"),
+                        batch_preds.get("batch_name"),
+                        batch_preds.get("batch"),
+                    ),
+                    batch_size,
+                )
+                pert_bcs = None
+                ctrl_bcs = None
+                if "pert_cell_barcode" in batch_preds:
+                    if isinstance(batch_preds["pert_cell_barcode"], list):
+                        pert_bcs = list(batch_preds["pert_cell_barcode"])
+                        ctrl_bcs = list(batch_preds["ctrl_cell_barcode"])
+                    else:
+                        pert_bcs = [batch_preds["pert_cell_barcode"]]
+                        ctrl_bcs = [batch_preds["ctrl_cell_barcode"]]
+
+                x_pred, x_real, om_pred, om_real = select_stream_payload(
+                    batch_preds, store_raw_expression, data_module.embed_key
+                )
+
+                if shared_perts is not None:
+                    keep = np.array(
+                        [p in shared_perts for p in pert_names], dtype=bool
+                    )
+                    if not keep.any():
+                        continue
+                    x_pred, x_real = x_pred[keep], x_real[keep]
+                    if om_pred is not None:
+                        om_pred = {k: v[keep] for k, v in om_pred.items()}
+                        om_real = {k: v[keep] for k, v in om_real.items()}
+                    sel = np.flatnonzero(keep)
+                    pert_names = [pert_names[i] for i in sel]
+                    celltypes = [celltypes[i] for i in sel]
+                    gem_groups = [gem_groups[i] for i in sel]
+                    if pert_bcs is not None:
+                        pert_bcs = [pert_bcs[i] for i in sel]
+                        ctrl_bcs = [ctrl_bcs[i] for i in sel]
+
+                pred_writer.write_block(x_pred, om_pred)
+                real_writer.write_block(x_real, om_real)
+                all_pert_names.extend(pert_names)
+                all_celltypes.extend(celltypes)
+                all_gem_groups.extend(gem_groups)
+                if pert_bcs is not None:
+                    all_pert_barcodes.extend(pert_bcs)
+                    all_ctrl_barcodes.extend(ctrl_bcs)
+
+        df_dict = {
+            data_module.pert_col: all_pert_names,
+            data_module.cell_type_key: all_celltypes,
+            batch_obs_key: all_gem_groups,
+        }
+        if data_module.batch_col and data_module.batch_col != batch_obs_key:
+            df_dict[data_module.batch_col] = all_gem_groups
+        if len(all_pert_barcodes) > 0:
+            df_dict["pert_cell_barcode"] = all_pert_barcodes
+            df_dict["ctrl_cell_barcode"] = all_ctrl_barcodes
+        obs = pd.DataFrame(df_dict)
+
+        pred_writer.close(obs)
+        real_writer.close(obs)
+        logger.info(f"Saved adata_pred to {adata_pred_path}")
+        logger.info(f"Saved adata_real to {adata_real_path}")
+        logger.info(
+            "Streaming complete; skipping in-process cell-eval. "
+            "Score the written h5ads downstream."
+        )
         return
 
     final_preds = np.empty((num_cells, output_dim), dtype=np.float32)

--- a/src/state/_cli/_tx/_stream_h5ad.py
+++ b/src/state/_cli/_tx/_stream_h5ad.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import anndata
+import h5py
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from anndata.io import write_elem
+
+# anndata h5ad encoding tags (verified on anndata 0.12.17; guarded by the
+# round-trip test in tests/test_stream_h5ad.py).
+_ANNDATA_ENCODING = ("anndata", "0.1.0")
+_ARRAY_ENCODING = ("array", "0.2.0")
+_DICT_ENCODING = ("dict", "0.1.0")
+# Empty optional groups anndata.write_h5ad always emits.
+_EMPTY_DICT_KEYS = ("layers", "uns", "obsp", "varm", "varp")
+
+
+def _to_numpy(value) -> np.ndarray:
+    """Convert a torch tensor or array-like batch field to a float32 ndarray."""
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu().numpy()
+    return np.asarray(value).astype(np.float32, copy=False)
+
+
+def select_stream_payload(
+    batch_preds: Mapping,
+    store_raw_expression: bool,
+    embed_key: str,
+) -> tuple[np.ndarray, np.ndarray, dict | None, dict | None]:
+    """Pick the X (and obsm) blocks for the pred/real writers from one batch.
+
+    Mirrors the AnnData assembly in ``run_tx_predict``:
+      - ``store_raw_expression``: X is the decoded gene expression
+        (pred=``pert_cell_counts_preds``, real=``pert_cell_counts``) and the
+        embeddings go to ``obsm[embed_key]`` (pred=``preds``, real=``pert_cell_emb``).
+      - otherwise: X is the embedding (pred=``preds``, real=``pert_cell_emb``)
+        and there is no obsm.
+
+    Returns ``(x_pred, x_real, obsm_pred, obsm_real)`` as float32 ndarrays;
+    ``obsm_*`` are ``{embed_key: arr}`` dicts or ``None``.
+    """
+    preds = _to_numpy(batch_preds["preds"])
+    reals = _to_numpy(batch_preds["pert_cell_emb"])
+    if store_raw_expression:
+        x_pred = _to_numpy(batch_preds["pert_cell_counts_preds"])
+        x_real = _to_numpy(batch_preds["pert_cell_counts"])
+        return x_pred, x_real, {embed_key: preds}, {embed_key: reals}
+    return preds, reals, None, None
+
+
+def validate_stream_adatas_args(args) -> None:
+    """Reject contradictory flag combinations for ``--stream-adatas``."""
+    if getattr(args, "stream_adatas", False) and getattr(args, "skip_adatas", False):
+        raise ValueError(
+            "--stream-adatas cannot be combined with --skip-adatas: streaming "
+            "exists to write the AnnData outputs to disk."
+        )
+
+
+class StreamingDenseH5ad:
+    """Incrementally write a dense AnnData (.h5ad) one row-block at a time.
+
+    Bounds peak host memory to a single block instead of the full
+    ``(n_obs, n_vars)`` matrix. ``n_obs`` / ``n_vars`` are fixed up front; obs
+    and var are written on ``close()``. The produced file is read-compatible
+    with ``anndata.AnnData(X=..., obs=..., obsm=...).write_h5ad`` for the same
+    data: X (and obsm) are dense float32 arrays, ``var`` carries the default
+    string index, and ``obs`` is normalized (string index + strings->categoricals)
+    the way ``write_h5ad`` normalizes it.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        n_obs: int,
+        n_vars: int,
+        *,
+        dtype: npt.DTypeLike = np.float32,
+        chunk_rows: int = 1024,
+        obsm: dict[str, int] | None = None,
+        clip: tuple[float, float] | None = (0.0, 14.0),
+    ) -> None:
+        self._path = path
+        self._n_obs = int(n_obs)
+        self._n_vars = int(n_vars)
+        self._clip = clip
+        self._cursor = 0
+        self._closed = False
+
+        self._file = h5py.File(path, "w")
+        (
+            self._file.attrs["encoding-type"],
+            self._file.attrs["encoding-version"],
+        ) = _ANNDATA_ENCODING
+
+        rows = min(chunk_rows, self._n_obs) or 1
+        self._x = self._file.create_dataset(
+            "X",
+            shape=(self._n_obs, self._n_vars),
+            maxshape=(self._n_obs, self._n_vars),
+            dtype=dtype,
+            chunks=(rows, self._n_vars),
+        )
+        self._x.attrs["encoding-type"], self._x.attrs["encoding-version"] = _ARRAY_ENCODING
+
+        self._obsm: dict[str, h5py.Dataset] = {}
+        if obsm:
+            grp = self._file.create_group("obsm")
+            grp.attrs["encoding-type"], grp.attrs["encoding-version"] = _DICT_ENCODING
+            for key, ncols in obsm.items():
+                ncols = int(ncols)
+                ds = grp.create_dataset(
+                    key,
+                    shape=(self._n_obs, ncols),
+                    maxshape=(self._n_obs, ncols),
+                    dtype=dtype,
+                    chunks=(rows, ncols),
+                )
+                ds.attrs["encoding-type"], ds.attrs["encoding-version"] = _ARRAY_ENCODING
+                self._obsm[key] = ds
+
+    def write_block(
+        self,
+        x_block: np.ndarray,
+        obsm_blocks: dict[str, np.ndarray] | None = None,
+    ) -> None:
+        if self._closed:
+            raise RuntimeError("write_block called after close()")
+        x = np.asarray(x_block, dtype=self._x.dtype)
+        n = x.shape[0]
+        end = self._cursor + n
+        if end > self._n_obs:
+            raise ValueError(
+                f"row overflow: writing rows up to {end} into n_obs={self._n_obs}"
+            )
+        if self._clip is not None:
+            np.clip(x, self._clip[0], self._clip[1], out=x)
+        self._x[self._cursor:end] = x
+        for key, ds in self._obsm.items():
+            if obsm_blocks is None or key not in obsm_blocks:
+                raise ValueError(f"missing obsm block for '{key}'")
+            ds[self._cursor:end] = np.asarray(obsm_blocks[key], dtype=ds.dtype)
+        self._cursor = end
+
+    def close(self, obs: pd.DataFrame, var: pd.DataFrame | None = None) -> None:
+        if self._closed:
+            return
+        # Shrink to the number of rows actually written (e.g. --shared-only).
+        if self._cursor != self._n_obs:
+            self._x.resize((self._cursor, self._n_vars))
+            for ds in self._obsm.values():
+                ds.resize((self._cursor, ds.shape[1]))
+        if len(obs) != self._cursor:
+            raise ValueError(
+                f"obs has {len(obs)} rows but {self._cursor} were written"
+            )
+        for key in _EMPTY_DICT_KEYS:
+            write_elem(self._file, key, {})
+        # Normalize obs exactly as AnnData.write_h5ad would (string index +
+        # strings->categoricals); write_elem alone does neither. Stringify the
+        # index first so anndata does not emit ImplicitModificationWarning.
+        obs = obs.copy()
+        obs.index = obs.index.astype(str)
+        obs_norm = anndata.AnnData(
+            X=np.empty((self._cursor, 0), dtype=np.float32), obs=obs
+        )
+        obs_norm.strings_to_categoricals()
+        write_elem(self._file, "obs", obs_norm.obs)
+        if var is None:
+            var = pd.DataFrame(index=pd.Index([str(i) for i in range(self._n_vars)]))
+        write_elem(self._file, "var", var)
+        self._file.close()
+        self._closed = True
+
+    def __enter__(self) -> "StreamingDenseH5ad":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        # On an exception before close(), release the file handle.
+        if exc_type is not None and not self._closed:
+            self._file.close()
+            self._closed = True

--- a/src/state/_cli/_tx/_stream_h5ad.py
+++ b/src/state/_cli/_tx/_stream_h5ad.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Mapping
+from types import TracebackType
+from typing import Any, Mapping
 
 import anndata
 import h5py
@@ -18,7 +19,7 @@ _DICT_ENCODING = ("dict", "0.1.0")
 _EMPTY_DICT_KEYS = ("layers", "uns", "obsp", "varm", "varp")
 
 
-def _to_numpy(value) -> np.ndarray:
+def _to_numpy(value: Any) -> np.ndarray:
     """Convert a torch tensor or array-like batch field to a float32 ndarray."""
     if hasattr(value, "detach"):
         value = value.detach()
@@ -31,7 +32,7 @@ def select_stream_payload(
     batch_preds: Mapping,
     store_raw_expression: bool,
     embed_key: str,
-) -> tuple[np.ndarray, np.ndarray, dict | None, dict | None]:
+) -> tuple[np.ndarray, np.ndarray, dict[str, np.ndarray] | None, dict[str, np.ndarray] | None]:
     """Pick the X (and obsm) blocks for the pred/real writers from one batch.
 
     Mirrors the AnnData assembly in ``run_tx_predict``:
@@ -180,7 +181,12 @@ class StreamingDenseH5ad:
     def __enter__(self) -> "StreamingDenseH5ad":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         # On an exception before close(), release the file handle.
         if exc_type is not None and not self._closed:
             self._file.close()

--- a/src/state/_cli/_tx/_stream_h5ad.py
+++ b/src/state/_cli/_tx/_stream_h5ad.py
@@ -122,9 +122,9 @@ class StreamingDenseH5ad:
         self._x.attrs["encoding-type"], self._x.attrs["encoding-version"] = _ARRAY_ENCODING
 
         self._obsm: dict[str, h5py.Dataset] = {}
+        grp = self._file.create_group("obsm")
+        grp.attrs["encoding-type"], grp.attrs["encoding-version"] = _DICT_ENCODING
         if obsm:
-            grp = self._file.create_group("obsm")
-            grp.attrs["encoding-type"], grp.attrs["encoding-version"] = _DICT_ENCODING
             for key, ncols in obsm.items():
                 ncols = int(ncols)
                 ds = grp.create_dataset(

--- a/src/state/_cli/_tx/_stream_h5ad.py
+++ b/src/state/_cli/_tx/_stream_h5ad.py
@@ -29,7 +29,7 @@ def _to_numpy(value: Any) -> np.ndarray:
 
 
 def select_stream_payload(
-    batch_preds: Mapping,
+    batch_preds: Mapping[str, Any],
     store_raw_expression: bool,
     embed_key: str,
 ) -> tuple[np.ndarray, np.ndarray, dict[str, np.ndarray] | None, dict[str, np.ndarray] | None]:
@@ -105,7 +105,9 @@ class StreamingDenseH5ad:
             shape=(self._n_obs, self._n_vars),
             maxshape=(self._n_obs, self._n_vars),
             dtype=dtype,
-            chunks=(rows, self._n_vars),
+            # A 0-row dataset cannot be chunked (chunk dim > data dim); it needs
+            # no chunking anyway since nothing is streamed into it.
+            chunks=(rows, self._n_vars) if self._n_obs > 0 else None,
         )
         self._x.attrs["encoding-type"], self._x.attrs["encoding-version"] = _ARRAY_ENCODING
 
@@ -120,7 +122,7 @@ class StreamingDenseH5ad:
                     shape=(self._n_obs, ncols),
                     maxshape=(self._n_obs, ncols),
                     dtype=dtype,
-                    chunks=(rows, ncols),
+                    chunks=(rows, ncols) if self._n_obs > 0 else None,
                 )
                 ds.attrs["encoding-type"], ds.attrs["encoding-version"] = _ARRAY_ENCODING
                 self._obsm[key] = ds

--- a/src/state/_cli/_tx/_stream_h5ad.py
+++ b/src/state/_cli/_tx/_stream_h5ad.py
@@ -56,6 +56,11 @@ def select_stream_payload(
 
 def validate_stream_adatas_args(args) -> None:
     """Reject contradictory flag combinations for ``--stream-adatas``."""
+    if getattr(args, "stream_adatas", False) and not getattr(args, "predict_only", False):
+        raise ValueError(
+            "--stream-adatas requires --predict-only because in-process "
+            "cell-eval is skipped in streaming mode."
+        )
     if getattr(args, "stream_adatas", False) and getattr(args, "skip_adatas", False):
         raise ValueError(
             "--stream-adatas cannot be combined with --skip-adatas: streaming "

--- a/src/state/_cli/_tx/_stream_h5ad.py
+++ b/src/state/_cli/_tx/_stream_h5ad.py
@@ -66,6 +66,11 @@ def validate_stream_adatas_args(args) -> None:
             "--stream-adatas cannot be combined with --skip-adatas: streaming "
             "exists to write the AnnData outputs to disk."
         )
+    if getattr(args, "stream_adatas", False) and getattr(args, "pseudobulk", False):
+        raise ValueError(
+            "--stream-adatas cannot be combined with --pseudobulk: pseudobulk "
+            "prediction already uses its own streaming aggregation path."
+        )
 
 
 class StreamingDenseH5ad:

--- a/tests/test_stream_h5ad.py
+++ b/tests/test_stream_h5ad.py
@@ -1,0 +1,116 @@
+import anndata
+import numpy as np
+import pandas as pd
+import pytest
+
+from state._cli._tx._stream_h5ad import (
+    StreamingDenseH5ad,
+    select_stream_payload,
+    validate_stream_adatas_args,
+)
+
+
+def _obs(n):
+    base = pd.DataFrame(
+        {"pert": ["a", "b", "a", "c", "b"], "ct": ["x", "x", "y", "y", "x"]}
+    )
+    return base.iloc[:n].reset_index(drop=True)
+
+
+def test_roundtrip_matches_in_memory_writer(tmp_path):
+    n, d, e = 5, 3, 4
+    x = np.arange(n * d, dtype=np.float32).reshape(n, d)
+    x[0, 0] = 99.0  # will be clipped to 14
+    emb = np.arange(n * e, dtype=np.float32).reshape(n, e)
+    obs = _obs(n)
+
+    p = str(tmp_path / "stream.h5ad")
+    w = StreamingDenseH5ad(p, n, d, obsm={"X_emb": e}, clip=(0.0, 14.0), chunk_rows=2)
+    w.write_block(x[:2], {"X_emb": emb[:2]})
+    w.write_block(x[2:], {"X_emb": emb[2:]})
+    w.close(obs)
+
+    # reference: the in-memory path clips X only, then writes
+    x_ref = x.copy()
+    np.clip(x_ref, 0.0, 14.0, out=x_ref)
+    obs_ref = obs.copy()
+    obs_ref.index = obs_ref.index.astype(str)
+    ref = anndata.AnnData(X=x_ref, obs=obs_ref)
+    ref.obsm["X_emb"] = emb
+    pr = str(tmp_path / "ref.h5ad")
+    ref.write_h5ad(pr)
+
+    a = anndata.read_h5ad(p)
+    r = anndata.read_h5ad(pr)
+    assert a.shape == r.shape
+    assert np.array_equal(a.X, r.X)
+    assert a.X[0, 0] == 14.0  # clipped
+    assert np.array_equal(a.obsm["X_emb"], r.obsm["X_emb"])
+    assert a.obsm["X_emb"].max() == emb.max()  # obsm NOT clipped
+    assert list(a.var.index) == list(r.var.index) == ["0", "1", "2"]
+    assert a.obs.equals(r.obs)
+
+
+def test_resize_down_for_shared_only(tmp_path):
+    n, d = 5, 3
+    x = np.arange(n * d, dtype=np.float32).reshape(n, d)
+    p = str(tmp_path / "short.h5ad")
+    w = StreamingDenseH5ad(p, n, d, clip=None, chunk_rows=2)
+    w.write_block(x[:3])  # only 3 of 5 rows actually written
+    w.close(_obs(3))
+    a = anndata.read_h5ad(p)
+    assert a.n_obs == 3
+    assert np.array_equal(a.X, x[:3])
+
+
+def test_row_overflow_raises(tmp_path):
+    w = StreamingDenseH5ad(str(tmp_path / "o.h5ad"), 2, 3, clip=None)
+    with pytest.raises(ValueError):
+        w.write_block(np.zeros((3, 3), dtype=np.float32))
+
+
+def test_obs_length_mismatch_raises(tmp_path):
+    w = StreamingDenseH5ad(str(tmp_path / "m.h5ad"), 2, 3, clip=None)
+    w.write_block(np.zeros((2, 3), dtype=np.float32))
+    with pytest.raises(ValueError):
+        w.close(_obs(1))
+
+
+def test_select_payload_embedding_space():
+    bp = {
+        "preds": np.ones((2, 4), dtype=np.float32),
+        "pert_cell_emb": np.zeros((2, 4), dtype=np.float32),
+    }
+    x_pred, x_real, om_pred, om_real = select_stream_payload(bp, False, "X_emb")
+    assert np.array_equal(x_pred, bp["preds"])
+    assert np.array_equal(x_real, bp["pert_cell_emb"])
+    assert om_pred is None and om_real is None
+
+
+def test_select_payload_gene_space():
+    bp = {
+        "preds": np.ones((2, 4), dtype=np.float32),
+        "pert_cell_emb": np.zeros((2, 4), dtype=np.float32),
+        "pert_cell_counts_preds": np.full((2, 6), 3.0, dtype=np.float32),
+        "pert_cell_counts": np.full((2, 6), 5.0, dtype=np.float32),
+    }
+    x_pred, x_real, om_pred, om_real = select_stream_payload(bp, True, "X_emb")
+    assert np.array_equal(x_pred, bp["pert_cell_counts_preds"])
+    assert np.array_equal(x_real, bp["pert_cell_counts"])
+    assert np.array_equal(om_pred["X_emb"], bp["preds"])
+    assert np.array_equal(om_real["X_emb"], bp["pert_cell_emb"])
+
+
+def test_validate_rejects_skip_and_stream():
+    class A:
+        stream_adatas = True
+        skip_adatas = True
+    with pytest.raises(ValueError):
+        validate_stream_adatas_args(A())
+
+
+def test_validate_allows_stream_alone():
+    class A:
+        stream_adatas = True
+        skip_adatas = False
+    validate_stream_adatas_args(A())  # no raise

--- a/tests/test_stream_h5ad.py
+++ b/tests/test_stream_h5ad.py
@@ -118,6 +118,7 @@ def test_validate_rejects_skip_and_stream():
         stream_adatas = True
         predict_only = True
         skip_adatas = True
+        pseudobulk = False
     with pytest.raises(ValueError):
         validate_stream_adatas_args(A())
 
@@ -127,6 +128,17 @@ def test_validate_rejects_stream_without_predict_only():
         stream_adatas = True
         predict_only = False
         skip_adatas = False
+        pseudobulk = False
+    with pytest.raises(ValueError):
+        validate_stream_adatas_args(A())
+
+
+def test_validate_rejects_pseudobulk_and_stream():
+    class A:
+        stream_adatas = True
+        predict_only = True
+        skip_adatas = False
+        pseudobulk = True
     with pytest.raises(ValueError):
         validate_stream_adatas_args(A())
 
@@ -136,4 +148,5 @@ def test_validate_allows_stream_alone():
         stream_adatas = True
         predict_only = True
         skip_adatas = False
+        pseudobulk = False
     validate_stream_adatas_args(A())  # no raise

--- a/tests/test_stream_h5ad.py
+++ b/tests/test_stream_h5ad.py
@@ -1,4 +1,5 @@
 import anndata
+import h5py
 import numpy as np
 import pandas as pd
 import pytest
@@ -61,6 +62,19 @@ def test_resize_down_for_shared_only(tmp_path):
     a = anndata.read_h5ad(p)
     assert a.n_obs == 3
     assert np.array_equal(a.X, x[:3])
+
+
+def test_writes_empty_obsm_group_without_embeddings(tmp_path):
+    p = str(tmp_path / "no_obsm_payload.h5ad")
+    w = StreamingDenseH5ad(p, 2, 3, clip=None)
+    w.write_block(np.ones((2, 3), dtype=np.float32))
+    w.close(_obs(2))
+
+    a = anndata.read_h5ad(p)
+    assert list(a.obsm.keys()) == []
+    with h5py.File(p, "r") as f:
+        assert "obsm" in f
+        assert f["obsm"].attrs["encoding-type"] == "dict"
 
 
 def test_empty_dataset(tmp_path):

--- a/tests/test_stream_h5ad.py
+++ b/tests/test_stream_h5ad.py
@@ -116,7 +116,17 @@ def test_select_payload_gene_space():
 def test_validate_rejects_skip_and_stream():
     class A:
         stream_adatas = True
+        predict_only = True
         skip_adatas = True
+    with pytest.raises(ValueError):
+        validate_stream_adatas_args(A())
+
+
+def test_validate_rejects_stream_without_predict_only():
+    class A:
+        stream_adatas = True
+        predict_only = False
+        skip_adatas = False
     with pytest.raises(ValueError):
         validate_stream_adatas_args(A())
 
@@ -124,5 +134,6 @@ def test_validate_rejects_skip_and_stream():
 def test_validate_allows_stream_alone():
     class A:
         stream_adatas = True
+        predict_only = True
         skip_adatas = False
     validate_stream_adatas_args(A())  # no raise

--- a/tests/test_stream_h5ad.py
+++ b/tests/test_stream_h5ad.py
@@ -63,6 +63,18 @@ def test_resize_down_for_shared_only(tmp_path):
     assert np.array_equal(a.X, x[:3])
 
 
+def test_empty_dataset(tmp_path):
+    # num_cells == 0 (empty test set / fully-masked shared-only) must still write
+    # a valid empty h5ad, matching the in-memory path's behavior.
+    p = str(tmp_path / "empty.h5ad")
+    w = StreamingDenseH5ad(p, 0, 3, obsm={"X_emb": 4}, clip=None)
+    w.close(_obs(0))
+    a = anndata.read_h5ad(p)
+    assert a.shape == (0, 3)
+    assert a.obsm["X_emb"].shape == (0, 4)
+    assert list(a.var.index) == ["0", "1", "2"]
+
+
 def test_row_overflow_raises(tmp_path):
     w = StreamingDenseH5ad(str(tmp_path / "o.h5ad"), 2, 3, clip=None)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

Adds an opt-in `--stream-adatas` flag to `state tx predict` that streams per-batch
predictions directly to `adata_pred.h5ad` / `adata_real.h5ad` on disk, bounding host
memory to roughly one batch instead of materializing the full `(n_cells, n_genes)`
prediction and ground-truth matrices in RAM.

## Motivation

The default predict path preallocates two dense `(n_cells, n_genes)` float32 arrays
(`final_preds`, `final_reals`) and fills them batch-by-batch before assembling the output
AnnData. On large held-out sets this is prohibitive: for an ~8.6M-cell × 18,151-gene
evaluation each buffer is ~580 GiB (~1.16 TiB combined), which exhausts host memory before
prediction completes. There was previously no way to run predict on such sets short of
subsampling or the `--pseudobulk` path.

## Changes

- **`_stream_h5ad.py` (new):** `StreamingDenseH5ad`, an incremental h5ad writer built on
  chunked, resizable HDF5 datasets. It writes one row-block per batch at a moving cursor,
  resizes down to the rows actually written on close, and stamps the AnnData encoding
  metadata so the file is a valid, `anndata`-readable `.h5ad`. `obs`/`var` are normalized on
  close exactly as `AnnData.write_h5ad` would (string index + `strings_to_categoricals`).
  Includes `select_stream_payload` (mirrors the in-memory X/obsm assembly) and
  `validate_stream_adatas_args`.
- **`_predict.py`:** new `--stream-adatas` branch. Purely additive — the existing in-memory
  path is unchanged, and streaming only runs when the flag is set. Honors
  `--shared-only` and `--store-raw-expression`; ignored (with a warning) under `--pseudobulk`,
  which already aggregates in a streaming fashion; rejected in combination with `--skip-adatas`.
- **`tests/test_stream_h5ad.py` (new):** round-trip equivalence against the in-memory
  AnnData assembly, plus edge cases (empty test set, `--shared-only` filtering).

Diffstat: 3 files, +489 / −0.

## Usage

```
state tx predict --checkpoint <ckpt> --output-dir <dir> --stream-adatas
```

Writes `adata_pred.h5ad` and `adata_real.h5ad` into `<output_dir>/eval_<ckpt>/`
(`eval_train_<ckpt>/` with `--eval-train-data`). `--stream-adatas` implies `--predict-only`:
in-process cell-eval is skipped, and the written h5ads are scored downstream.

## Testing

- `tests/test_stream_h5ad.py` passes (round-trip + edge cases).
- Validated end-to-end on a held-out perturbation eval (~8.6M cells × 18,151 genes, 5
  held-out cell lines): predict completed with peak host RSS ~238 GiB and flat memory over
  the run, versus the full-materialization path OOMing on the same workload. Downstream
  cell-eval scoring of the streamed h5ads produced complete DE metrics for all cell lines.

## Compatibility

Opt-in and fully backward compatible: default behavior is unchanged when the flag is absent.
