### PR TITLE
feat: support on-the-fly raw count normalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arc-state"
-version = "0.11.2"
+version = "0.11.3"
 description = "State is a machine learning model that predicts cellular perturbation response across diverse contexts."
 readme = "README.md"
 authors = [

--- a/src/state/configs/model/context_mean.yaml
+++ b/src/state/configs/model/context_mean.yaml
@@ -16,6 +16,9 @@ kwargs:
   finetune_vci_decoder: False
   batch_encoder: False
   distributional_loss: energy
+  # Convert raw counts to log1p(CP(counts_target_sum)) inside the model.
+  log1p_from_raw_counts: False
+  counts_target_sum: 10000
   transformer_backbone_key: GPT2
   transformer_backbone_kwargs:
       n_positions: ${model.kwargs.cell_set_len}

--- a/src/state/configs/model/perturb_mean.yaml
+++ b/src/state/configs/model/perturb_mean.yaml
@@ -16,6 +16,9 @@ kwargs:
   transformer_decoder: False
   finetune_vci_decoder: False
   distributional_loss: energy
+  # Convert raw counts to log1p(CP(counts_target_sum)) inside the model.
+  log1p_from_raw_counts: False
+  counts_target_sum: 10000
   transformer_backbone_key: GPT2
   transformer_backbone_kwargs:
       n_positions: ${model.kwargs.cell_set_len}

--- a/src/state/configs/model/state.yaml
+++ b/src/state/configs/model/state.yaml
@@ -20,6 +20,10 @@ kwargs:
   use_batch_token: False
   mask_attn: False
 
+  # Convert raw counts to log1p(CP(counts_target_sum)) inside the model.
+  log1p_from_raw_counts: False
+  counts_target_sum: 10000
+
   use_effect_gating_token: False
   distributional_loss: energy
   init_from: null

--- a/src/state/tx/models/base.py
+++ b/src/state/tx/models/base.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
@@ -181,6 +182,11 @@ class PerturbationModel(ABC, LightningModule):
         self.batch_size = batch_size
         self.control_pert = control_pert
 
+        self.log1p_from_raw_counts = bool(kwargs.get("log1p_from_raw_counts", False))
+        self.counts_target_sum = float(kwargs.get("counts_target_sum", 10_000.0))
+        if self.log1p_from_raw_counts and (not math.isfinite(self.counts_target_sum) or self.counts_target_sum <= 0):
+            raise ValueError("counts_target_sum must be positive and finite")
+
         # Training settings
         self.gene_names = gene_names  # store the gene names that this model output for gene expression space
         self.dropout = dropout
@@ -202,6 +208,33 @@ class PerturbationModel(ABC, LightningModule):
 
     def transfer_batch_to_device(self, batch, device, dataloader_idx: int):
         return {k: (v.to(device, non_blocking=True) if isinstance(v, torch.Tensor) else v) for k, v in batch.items()}
+
+    def _cp_log1p(self, value: torch.Tensor) -> torch.Tensor:
+        """Normalize each count vector to ``counts_target_sum`` and apply log1p."""
+        counts = value.float().clamp_min(0)
+        totals = counts.sum(dim=-1, keepdim=True)
+        scale = torch.where(
+            totals > 0,
+            self.counts_target_sum / totals,
+            torch.zeros_like(totals),
+        )
+        return torch.log1p(counts * scale)
+
+    def _normalize_count_keys(self, batch: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """Return count-space batch tensors in log1p(CP(target_sum)) space."""
+        if not self.log1p_from_raw_counts:
+            return batch
+
+        keys = ["pert_cell_counts"]
+        if self.embed_key in (None, "X_hvg"):
+            keys.extend(("ctrl_cell_emb", "pert_cell_emb"))
+
+        normalized = dict(batch)
+        for key in keys:
+            value = normalized.get(key)
+            if isinstance(value, torch.Tensor):
+                normalized[key] = self._cp_log1p(value)
+        return normalized
 
     @abstractmethod
     def _build_networks(self):
@@ -296,6 +329,7 @@ class PerturbationModel(ABC, LightningModule):
 
     def training_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> torch.Tensor:
         """Training step logic for both main model and decoder."""
+        batch = self._normalize_count_keys(batch)
         # Get model predictions (in latent space)
         pred = self(batch)
 
@@ -325,6 +359,7 @@ class PerturbationModel(ABC, LightningModule):
 
     def validation_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> None:
         """Validation step logic."""
+        batch = self._normalize_count_keys(batch)
         pred = self(batch)
         loss = self.loss_fn(pred, batch["pert_cell_emb"])
 
@@ -335,6 +370,7 @@ class PerturbationModel(ABC, LightningModule):
         return {"loss": loss, "predictions": pred}
 
     def test_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> None:
+        batch = self._normalize_count_keys(batch)
         latent_output = self(batch)
         target = batch[self.embed_key]
         loss = self.loss_fn(latent_output, target)
@@ -362,6 +398,7 @@ class PerturbationModel(ABC, LightningModule):
         Typically used for final inference. We'll replicate old logic:
          returning 'preds', 'X', 'pert_name', etc.
         """
+        batch = self._normalize_count_keys(batch)
         latent_output = self.forward(batch)
         output_dict = {
             "preds": latent_output,

--- a/src/state/tx/models/context_mean.py
+++ b/src/state/tx/models/context_mean.py
@@ -102,6 +102,7 @@ class ContextMeanPerturbationModel(PerturbationModel):
 
         with torch.no_grad():
             for batch in train_loader:
+                batch = self._normalize_count_keys(batch)
                 # Select the proper expression space
                 if (self.embed_key and self.embed_key != "X_hvg" and self.output_space == "gene") or (
                     self.embed_key and self.output_space == "all"
@@ -205,6 +206,7 @@ class ContextMeanPerturbationModel(PerturbationModel):
         Returns:
             torch.Tensor: The computed loss.
         """
+        batch = self._normalize_count_keys(batch)
         pred = self(batch)
         output_key = (
             "pert_cell_counts"

--- a/src/state/tx/models/perturb_mean.py
+++ b/src/state/tx/models/perturb_mean.py
@@ -100,6 +100,7 @@ class PerturbMeanPerturbationModel(PerturbationModel):
 
         with torch.no_grad():
             for batch in train_loader:
+                batch = self._normalize_count_keys(batch)
                 if (
                     self.embed_key
                     and self.embed_key != "X_hvg"
@@ -208,6 +209,7 @@ class PerturbMeanPerturbationModel(PerturbationModel):
         """
         We'll compute MSE vs. the ground truth. (Though no real learnable offsets.)
         """
+        batch = self._normalize_count_keys(batch)
         pred = self(batch)
         if (self.embed_key and self.embed_key != "X_hvg" and self.output_space == "gene") or (
             self.embed_key and self.output_space == "all"

--- a/src/state/tx/models/state_transition.py
+++ b/src/state/tx/models/state_transition.py
@@ -542,6 +542,7 @@ class StateTransitionPerturbationModel(PerturbationModel):
 
     def training_step(self, batch: Dict[str, torch.Tensor], batch_idx: int, padded=True) -> torch.Tensor:
         """Training step logic for both main model and decoder."""
+        batch = self._normalize_count_keys(batch)
         # Get model predictions (in latent space)
         confidence_pred = None
         if self.confidence_token is not None:
@@ -683,6 +684,7 @@ class StateTransitionPerturbationModel(PerturbationModel):
 
     def validation_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> None:
         """Validation step logic."""
+        batch = self._normalize_count_keys(batch)
         if self.confidence_token is None:
             pred, confidence_pred = self.forward(batch), None
         else:
@@ -737,6 +739,7 @@ class StateTransitionPerturbationModel(PerturbationModel):
         return {"loss": loss, "predictions": pred}
 
     def test_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> None:
+        batch = self._normalize_count_keys(batch)
         if self.confidence_token is None:
             pred, confidence_pred = self.forward(batch, padded=False), None
         else:
@@ -766,6 +769,7 @@ class StateTransitionPerturbationModel(PerturbationModel):
         Typically used for final inference. We'll replicate old logic:s
          returning 'preds', 'X', 'pert_name', etc.
         """
+        batch = self._normalize_count_keys(batch)
         if self.confidence_token is None:
             latent_output = self.forward(batch, padded=padded)  # shape [B, ...]
             confidence_pred = None

--- a/tests/test_raw_count_normalization.py
+++ b/tests/test_raw_count_normalization.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-import torch.nn as nn
+from torch import nn
 
 from state.tx.models.base import PerturbationModel
 from state.tx.models.context_mean import ContextMeanPerturbationModel

--- a/tests/test_raw_count_normalization.py
+++ b/tests/test_raw_count_normalization.py
@@ -1,0 +1,177 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from state.tx.models.base import PerturbationModel
+from state.tx.models.context_mean import ContextMeanPerturbationModel
+from state.tx.models.perturb_mean import PerturbMeanPerturbationModel
+
+
+class _IdentityPerturbationModel(PerturbationModel):
+    def _build_networks(self):
+        pass
+
+    def forward(self, batch):
+        return batch["ctrl_cell_emb"]
+
+
+def _model(**kwargs):
+    return _IdentityPerturbationModel(
+        input_dim=3,
+        hidden_dim=3,
+        output_dim=3,
+        pert_dim=1,
+        loss_fn=nn.MSELoss(),
+        output_space="all",
+        gene_decoder_bool=False,
+        **kwargs,
+    )
+
+
+def test_cp10k_log1p_normalizes_each_cell():
+    model = _model(
+        embed_key="X_hvg",
+        log1p_from_raw_counts=True,
+        counts_target_sum=10_000,
+    )
+    counts = torch.tensor([[1.0, 3.0, 0.0], [0.0, 0.0, 0.0]])
+
+    actual = model._cp_log1p(counts)
+    expected = torch.log1p(torch.tensor([[2_500.0, 7_500.0, 0.0], [0.0, 0.0, 0.0]]))
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_count_batch_normalization_does_not_mutate_input():
+    model = _model(embed_key="X_hvg", log1p_from_raw_counts=True)
+    counts = torch.tensor([[1.0, 3.0, 0.0]])
+    batch = {
+        "ctrl_cell_emb": counts,
+        "pert_cell_emb": counts * 2,
+        "pert_cell_counts": counts * 3,
+        "pert_emb": torch.tensor([[1.0]]),
+    }
+
+    normalized = model._normalize_count_keys(batch)
+
+    assert normalized is not batch
+    assert normalized["pert_emb"] is batch["pert_emb"]
+    torch.testing.assert_close(batch["ctrl_cell_emb"], counts)
+    for key in ("ctrl_cell_emb", "pert_cell_emb", "pert_cell_counts"):
+        torch.testing.assert_close(normalized[key].expm1().sum(dim=-1), torch.tensor([10_000.0]))
+
+
+def test_learned_embeddings_are_not_normalized():
+    model = _model(embed_key="X_state", log1p_from_raw_counts=True)
+    embedding = torch.tensor([[1.0, -2.0, 3.0]])
+    counts = torch.tensor([[1.0, 3.0, 0.0]])
+    batch = {
+        "ctrl_cell_emb": embedding,
+        "pert_cell_emb": embedding,
+        "pert_cell_counts": counts,
+    }
+
+    normalized = model._normalize_count_keys(batch)
+
+    assert normalized["ctrl_cell_emb"] is embedding
+    assert normalized["pert_cell_emb"] is embedding
+    torch.testing.assert_close(
+        normalized["pert_cell_counts"].expm1().sum(dim=-1),
+        torch.tensor([10_000.0]),
+    )
+
+
+def test_normalization_is_disabled_by_default():
+    model = _model(embed_key="X_hvg")
+    batch = {"pert_cell_emb": torch.tensor([[1.0, 2.0, 3.0]])}
+
+    assert model._normalize_count_keys(batch) is batch
+
+
+def test_counts_target_sum_must_be_positive():
+    with pytest.raises(ValueError, match="counts_target_sum must be positive"):
+        _model(
+            embed_key="X_hvg",
+            log1p_from_raw_counts=True,
+            counts_target_sum=0,
+        )
+
+
+def test_predict_step_returns_normalized_real_values():
+    model = _model(embed_key="X_hvg", log1p_from_raw_counts=True)
+    counts = torch.tensor([[1.0, 3.0, 0.0]])
+    batch = {
+        "ctrl_cell_emb": counts,
+        "pert_cell_emb": counts * 2,
+        "pert_cell_counts": counts * 3,
+        "pert_name": ["P1"],
+        "cell_type": ["CT1"],
+    }
+
+    output = model.predict_step(batch, batch_idx=0)
+
+    for key in ("preds", "ctrl_cell_emb", "pert_cell_emb", "pert_cell_counts"):
+        torch.testing.assert_close(output[key].expm1().sum(dim=-1), torch.tensor([10_000.0]))
+
+
+def _raw_mean_batch():
+    return {
+        "ctrl_cell_emb": torch.tensor([[1.0, 3.0, 0.0], [1.0, 3.0, 0.0]]),
+        "pert_cell_emb": torch.tensor([[1.0, 3.0, 0.0], [3.0, 1.0, 0.0]]),
+        "pert_cell_counts": torch.tensor([[1.0, 3.0, 0.0], [3.0, 1.0, 0.0]]),
+        "pert_name": ["control", "P1"],
+        "cell_type": ["CT1", "CT1"],
+    }
+
+
+def _attach_train_batch(model, batch):
+    datamodule = SimpleNamespace(train_dataloader=lambda: [batch])
+    model._trainer = SimpleNamespace(datamodule=datamodule)
+
+
+def test_perturb_mean_fits_offsets_in_normalized_space():
+    model = PerturbMeanPerturbationModel(
+        input_dim=3,
+        hidden_dim=3,
+        output_dim=3,
+        pert_dim=1,
+        loss_fn=nn.MSELoss(),
+        control_pert="control",
+        embed_key="X_hvg",
+        output_space="all",
+        gene_decoder_bool=False,
+        log1p_from_raw_counts=True,
+    )
+    batch = _raw_mean_batch()
+    _attach_train_batch(model, batch)
+
+    model.on_fit_start()
+
+    ctrl = model._cp_log1p(batch["pert_cell_counts"][:1]).squeeze(0)
+    pert = model._cp_log1p(batch["pert_cell_counts"][1:]).squeeze(0)
+    torch.testing.assert_close(model.global_basal, ctrl)
+    torch.testing.assert_close(model.pert_mean_offsets["P1"], pert - ctrl)
+
+
+def test_context_mean_fits_means_in_normalized_space():
+    model = ContextMeanPerturbationModel(
+        input_dim=3,
+        hidden_dim=3,
+        output_dim=3,
+        pert_dim=1,
+        loss_fn=nn.MSELoss(),
+        control_pert="control",
+        embed_key="X_hvg",
+        output_space="all",
+        gene_decoder_bool=False,
+        log1p_from_raw_counts=True,
+    )
+    batch = _raw_mean_batch()
+    _attach_train_batch(model, batch)
+
+    model.on_fit_start()
+
+    expected = model._cp_log1p(batch["pert_cell_counts"][1:]).squeeze(0)
+    torch.testing.assert_close(model.celltype_pert_means["CT1"], expected)


### PR DESCRIPTION
## Summary

- add optional per-cell `normalize_total` plus `log1p` conversion for raw-count perturbation workflows
- apply the conversion consistently during train, validation, test, prediction, and PerturbMean/ContextMean fitting
- keep the feature disabled by default for backward compatibility
- bump `arc-state` from 0.11.2 to 0.11.3

## Usage

Enable for State, PerturbMean, or ContextMean with:

```text
model.kwargs.log1p_from_raw_counts=true
model.kwargs.counts_target_sum=10000
data.kwargs.is_log1p=false
```

`counts_target_sum` is configurable and must be positive and finite. Learned embedding inputs are not normalized; raw gene-count inputs are.

## Dependency boundary

This PR does not include or require SCX support. `pyproject.toml` retains `cell-load>=0.10.4`, and neither the project dependencies nor source code reference `pyscx`/SCX. The feature was tested through H5AD in an isolated environment where `pyscx` was absent.

## Verification

- `pytest -q`: 37 passed
- focused raw-count normalization tests: 8 passed
- Ruff check for the new test: passed
- Ruff format check for changed Python files: passed
- H5AD-only PerturbMean and ContextMean smoke: passed with `pyscx` absent
